### PR TITLE
feat: customisable source/sound mode names, subwoofer level slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
-# Samsung Soundbar **Local** – Home Assistant Integration
+# Samsung Soundbar **Local** – Home Assistant Integration (Fork)
 
-> **Local IP control for 2024-line Samsung Wi-Fi soundbars**  
+> **This is a fork of [hass-samsung-soundbar-local](https://github.com/ZtF/hass-samsung-soundbar-local) by [@ZtF](https://github.com/ZtF).**
+> All credit for the original integration goes to them.
+
+> **Local IP control for 2024-line Samsung Wi-Fi soundbars**
 > HW-Q990D · HW-Q800D · HW-QS730D · HW-S800D · HW-S801D · HW-S700D · HW-S60D · HW-S61D · HW-LS60D
+
+---
+
+## What changed in this fork?
+
+- **Customisable input source names** – Rename or hide any input source via the integration's options page.
+- **Customisable sound mode names** – Same for sound modes.
+- **Subwoofer level slider** – A number entity (`number.soundbar_<ip>_subwoofer_level`) exposed as a slider so you can set the subwoofer level directly from Home Assistant dashboards and automations.
 
 ---
 
 ## What is it?
 
-`soundbar_local` is a custom Home Assistant component that talks **directly** to your 2024 Samsung soundbar over the LAN (TCP 1516, same JSON-RPC API used by the SmartThings app).  
+`soundbar_local` is a custom Home Assistant component that talks **directly** to your 2024 Samsung soundbar over the LAN (TCP 1516, same JSON-RPC API used by the SmartThings app).
 No cloud, no SmartThings integration in Home Assistant – everything stays on your network.
 
 ### Key features
@@ -16,9 +27,10 @@ No cloud, no SmartThings integration in Home Assistant – everything stays on y
 |----------|---------|
 | Power control | `turn_on`, `turn_off` |
 | Audio | volume **set / step / mute** |
-| Subwoofer | woofer ± (not presented to Home Assistant yet) |
-| Inputs | HDMI1, E-ARC, ARC, Digital, Bluetooth, Wi-Fi |
-| Sound modes | Standard, Surround, Game, Movie, Music, Clear Voice, DTS Virtual X, Adaptive |
+| Subwoofer | level slider (-12 to +6) + woofer ± buttons |
+| Inputs | Configurable – rename or hide any source |
+| Sound modes | Configurable – rename or hide any mode |
+| Options page | Customise display names for sources and sound modes |
 
 The entity is exposed as `media_player.soundbar_<ipaddr>` and works with dashboards, automations and scripts just like any other media-player device.
 
@@ -26,7 +38,7 @@ The entity is exposed as `media_player.soundbar_<ipaddr>` and works with dashboa
 
 ## Supported models
 
-* HW-Q990D  – HW-Q800D  – HW-QS730D  
+* HW-Q990D  – HW-Q800D  – HW-QS730D
 * HW-S800D  – HW-S801D  – HW-S700D  – HW-S60D  – HW-S61D  – HW-LS60D
 
 > Older (2023 and below) bars do **not** implement the same API and will **not** work.
@@ -35,21 +47,90 @@ The entity is exposed as `media_player.soundbar_<ipaddr>` and works with dashboa
 
 ## Requirements
 
-* Home Assistant 2023.12 or newer  
-* Python 3.11 (bundled with HA OS / Container)  
-* Your soundbar **added to the Samsung SmartThings app, connected to Wi-Fi** and  
-  **“IP control” enabled** in the device settings.  
+* Home Assistant 2024.3.0 or newer
+* Python 3.11 (bundled with HA OS / Container)
+* Your soundbar **added to the Samsung SmartThings app, connected to Wi-Fi** and
+  **"IP control" enabled** in the device settings.
   This setting allows the bar to produce an *Access Token* that the integration uses.
 
 ---
 
 ## Installation
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=ZtF&repository=hass-samsung-soundbar-local&category=integration)
+### Option 1: HACS (recommended)
 
+1. Open HACS in your Home Assistant instance.
+2. Go to **Integrations → ⋮ (three dots) → Custom repositories**.
+3. Add the URL of this fork repository and select **Integration** as the category.
+4. Search for **Samsung Soundbar Local** in HACS and install it.
+5. Restart Home Assistant.
+6. Go to **Settings → Devices & Services → + Add Integration**, search for
+   **"Samsung Soundbar Local"**, enter the soundbar's IP address and confirm.
 
-1. **Download the latest ZIP** from the [releases](https://github.com/ZtF/hass-samsung-soundbar-local/releases) page.  
-2. Unzip to `<config>/custom_components/`
-3. Restart Home Assistant.  
-4. Go to **Settings → Devices & Services → + Add Integration**, search for  
-**“Samsung Soundbar Local”**, enter the soundbar’s IP address and confirm.
+### Option 2: Manual install from release
+
+1. **Download the latest ZIP** from the [Releases](../../releases) page.
+2. Unzip to `<config>/custom_components/` (you should end up with
+   `<config>/custom_components/samsung_soundbar_local/`).
+3. Restart Home Assistant.
+4. Go to **Settings → Devices & Services → + Add Integration**, search for
+   **"Samsung Soundbar Local"**, enter the soundbar's IP address and confirm.
+
+---
+
+## Configuring display names
+
+After adding the integration, go to **Settings → Devices & Services**, find
+**Samsung Soundbar Local**, click **Configure**.
+
+You will see two options:
+
+- **Input sources** – Set a display name for each input. Leave a field blank to
+  hide that source from the media player UI.
+- **Sound modes** – Same for sound modes.
+
+Changes take effect after saving (the integration reloads automatically).
+
+---
+
+## Subwoofer level
+
+The integration exposes a **number entity** (`number.soundbar_<ip>_subwoofer_level`)
+that appears as a slider ranging from -12 to +6.
+
+> **Note:** The Samsung API only supports incremental +/- commands for the
+> subwoofer. The integration tracks the level locally and restores it across
+> restarts. If you change the level using the physical remote or SmartThings app,
+> the slider may become out of sync. Adjust it once via Home Assistant to
+> re-calibrate.
+
+---
+
+## Creating a release
+
+Follow these steps to create a new release of this integration:
+
+1. **Update the version** in `custom_components/samsung_soundbar_local/manifest.json`.
+2. **Commit and push** your changes.
+3. **Create a ZIP archive** of the integration folder:
+   ```bash
+   cd custom_components
+   zip -r samsung_soundbar_local.zip samsung_soundbar_local/
+   ```
+4. **Create a GitHub release:**
+   - Go to your fork on GitHub → **Releases** → **Draft a new release**.
+   - Click **Choose a tag**, type a version (e.g. `v1.1.0`), and select
+     **Create new tag on publish**.
+   - Set the **Release title** (e.g. `v1.1.0`).
+   - Write release notes describing the changes.
+   - **Attach** the `samsung_soundbar_local.zip` file you created.
+   - Click **Publish release**.
+
+---
+
+## Credits
+
+This integration is a fork of the excellent work by **[@ZtF](https://github.com/ZtF)**:
+<https://github.com/ZtF/hass-samsung-soundbar-local>
+
+All original design, API reverse-engineering, and implementation credit belongs to them.

--- a/custom_components/samsung_soundbar_local/__init__.py
+++ b/custom_components/samsung_soundbar_local/__init__.py
@@ -62,7 +62,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
+
     return True
+
+
+async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the integration when options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/samsung_soundbar_local/config_flow.py
+++ b/custom_components/samsung_soundbar_local/config_flow.py
@@ -7,7 +7,16 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import CONF_VERIFY_SSL, DOMAIN
+from .const import (
+    ALL_SOUND_MODES,
+    ALL_SOURCES,
+    CONF_SOUND_MODE_NAMES,
+    CONF_SOURCE_NAMES,
+    CONF_VERIFY_SSL,
+    DEFAULT_SOUND_MODE_NAMES,
+    DEFAULT_SOURCE_NAMES,
+    DOMAIN,
+)
 
 
 class SoundbarLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -30,4 +39,72 @@ class SoundbarLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional(CONF_VERIFY_SSL, default=False): bool,
                 }
             ),
+        )
+
+    @staticmethod
+    def async_get_options_flow(config_entry):
+        return SoundbarLocalOptionsFlow(config_entry)
+
+
+class SoundbarLocalOptionsFlow(config_entries.OptionsFlow):
+    """Handle options flow for customising display names."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self._config_entry = config_entry
+
+    async def async_step_init(self, user_input: dict | None = None) -> FlowResult:
+        """Show the main options menu."""
+        return self.async_show_menu(
+            step_id="init",
+            menu_options=["sources", "sound_modes"],
+        )
+
+    async def async_step_sources(self, user_input: dict | None = None) -> FlowResult:
+        """Configure source display names."""
+        current = self._config_entry.options.get(CONF_SOURCE_NAMES, {})
+
+        if user_input is not None:
+            new_opts = dict(self._config_entry.options)
+            new_opts[CONF_SOURCE_NAMES] = {
+                api_name: user_input.get(api_name, "")
+                for api_name in ALL_SOURCES
+            }
+            return self.async_create_entry(title="", data=new_opts)
+
+        schema_fields: dict = {}
+        for api_name in ALL_SOURCES:
+            default = current.get(api_name, DEFAULT_SOURCE_NAMES.get(api_name, api_name))
+            schema_fields[vol.Optional(api_name, default=default)] = str
+
+        return self.async_show_form(
+            step_id="sources",
+            data_schema=vol.Schema(schema_fields),
+            description_placeholders={
+                "instructions": "Enter a display name for each input source. Leave blank to hide the source from the UI."
+            },
+        )
+
+    async def async_step_sound_modes(self, user_input: dict | None = None) -> FlowResult:
+        """Configure sound mode display names."""
+        current = self._config_entry.options.get(CONF_SOUND_MODE_NAMES, {})
+
+        if user_input is not None:
+            new_opts = dict(self._config_entry.options)
+            new_opts[CONF_SOUND_MODE_NAMES] = {
+                api_name: user_input.get(api_name, "")
+                for api_name in ALL_SOUND_MODES
+            }
+            return self.async_create_entry(title="", data=new_opts)
+
+        schema_fields: dict = {}
+        for api_name in ALL_SOUND_MODES:
+            default = current.get(api_name, DEFAULT_SOUND_MODE_NAMES.get(api_name, api_name))
+            schema_fields[vol.Optional(api_name, default=default)] = str
+
+        return self.async_show_form(
+            step_id="sound_modes",
+            data_schema=vol.Schema(schema_fields),
+            description_placeholders={
+                "instructions": "Enter a display name for each sound mode. Leave blank to hide the mode from the UI."
+            },
         )

--- a/custom_components/samsung_soundbar_local/const.py
+++ b/custom_components/samsung_soundbar_local/const.py
@@ -1,7 +1,54 @@
 DOMAIN = "soundbar_local"
 
-PLATFORMS = ["button", "media_player"]
+PLATFORMS = ["button", "media_player", "number"]
 
 DEFAULT_POLL_INTERVAL = 10  # seconds
 
 CONF_VERIFY_SSL = "verify_ssl"
+CONF_SOURCE_NAMES = "source_names"
+CONF_SOUND_MODE_NAMES = "sound_mode_names"
+
+# All possible API source identifiers
+ALL_SOURCES = [
+    "HDMI_IN1",
+    "HDMI_IN2",
+    "E_ARC",
+    "ARC",
+    "D_IN",
+    "BT",
+    "WIFI_IDLE",
+]
+
+# All possible API sound mode identifiers
+ALL_SOUND_MODES = [
+    "STANDARD",
+    "SURROUND",
+    "GAME",
+    "MOVIE",
+    "MUSIC",
+    "CLEARVOICE",
+    "DTS_VIRTUAL_X",
+    "ADAPTIVE",
+]
+
+# Default display names (empty string = hidden from UI)
+DEFAULT_SOURCE_NAMES: dict[str, str] = {
+    "HDMI_IN1": "HDMI 1",
+    "HDMI_IN2": "HDMI 2",
+    "E_ARC": "eARC",
+    "ARC": "ARC",
+    "D_IN": "Digital In",
+    "BT": "Bluetooth",
+    "WIFI_IDLE": "Wi-Fi",
+}
+
+DEFAULT_SOUND_MODE_NAMES: dict[str, str] = {
+    "STANDARD": "Standard",
+    "SURROUND": "Surround",
+    "GAME": "Game",
+    "MOVIE": "Movie",
+    "MUSIC": "Music",
+    "CLEARVOICE": "Clear Voice",
+    "DTS_VIRTUAL_X": "DTS Virtual X",
+    "ADAPTIVE": "Adaptive Sound",
+}

--- a/custom_components/samsung_soundbar_local/manifest.json
+++ b/custom_components/samsung_soundbar_local/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "soundbar_local",
   "name": "Samsung Soundbar Local",
-  "version": "1.0",
+  "version": "1.1.0",
   "config_flow": true,
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8"],
-  "codeowners": ["@ZtF"],
-  "documentation": "https://github.com/ZtF/hass-samsung-soundbar-local"
+  "codeowners": ["@ZtF", "@Potvis"],
+  "documentation": "https://github.com/Potvis/hass-samsung-soundbar-local"
 }

--- a/custom_components/samsung_soundbar_local/media_player.py
+++ b/custom_components/samsung_soundbar_local/media_player.py
@@ -15,7 +15,15 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.config_entries import ConfigEntry
 
-from .const import DOMAIN
+from .const import (
+    ALL_SOUND_MODES,
+    ALL_SOURCES,
+    CONF_SOUND_MODE_NAMES,
+    CONF_SOURCE_NAMES,
+    DEFAULT_SOUND_MODE_NAMES,
+    DEFAULT_SOURCE_NAMES,
+    DOMAIN,
+)
 from .soundbar import AsyncSoundbar
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,26 +38,19 @@ _SUPPORTED: MediaPlayerEntityFeature = (
     | MediaPlayerEntityFeature.SELECT_SOUND_MODE
 )
 
-_SOURCES = [
-    "HDMI_IN1",
-    "HDMI_IN2",
-    "E_ARC",
-    "ARC",
-    "D_IN",
-    "BT",
-    "WIFI_IDLE",
-]
 
-_SOUND_MODES = [
-    "STANDARD",
-    "SURROUND",
-    "GAME",
-    "MOVIE",
-    "MUSIC",
-    "CLEARVOICE",
-    "DTS_VIRTUAL_X",
-    "ADAPTIVE",
-]
+def _build_mapping(
+    api_names: list[str],
+    defaults: dict[str, str],
+    overrides: dict[str, str],
+) -> dict[str, str]:
+    """Build {api_name: display_name} mapping, dropping empty display names."""
+    mapping: dict[str, str] = {}
+    for api_name in api_names:
+        display = overrides.get(api_name, defaults.get(api_name, api_name))
+        if display:  # empty string = hidden
+            mapping[api_name] = display
+    return mapping
 
 
 async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities):
@@ -65,8 +66,6 @@ class SoundbarLocalEntity(CoordinatorEntity, MediaPlayerEntity):
     """Representation of the soundbar as a Media Player entity."""
 
     _attr_supported_features = _SUPPORTED
-    _attr_source_list = _SOURCES
-    _attr_sound_mode_list = _SOUND_MODES
     _attr_device_class = MediaPlayerDeviceClass.SPEAKER
 
     def __init__(self, coordinator, soundbar: AsyncSoundbar, entry: ConfigEntry) -> None:
@@ -83,6 +82,30 @@ class SoundbarLocalEntity(CoordinatorEntity, MediaPlayerEntity):
             model="Soundbar",
             name=self._attr_name,
         )
+
+        self._refresh_mappings()
+
+    def _refresh_mappings(self) -> None:
+        """Rebuild display-name mappings from current options."""
+        opts = self._entry.options
+
+        self._source_map = _build_mapping(
+            ALL_SOURCES,
+            DEFAULT_SOURCE_NAMES,
+            opts.get(CONF_SOURCE_NAMES, {}),
+        )
+        self._sound_mode_map = _build_mapping(
+            ALL_SOUND_MODES,
+            DEFAULT_SOUND_MODE_NAMES,
+            opts.get(CONF_SOUND_MODE_NAMES, {}),
+        )
+
+        # Reverse maps: display_name -> api_name
+        self._source_reverse = {v: k for k, v in self._source_map.items()}
+        self._sound_mode_reverse = {v: k for k, v in self._sound_mode_map.items()}
+
+        self._attr_source_list = list(self._source_map.values())
+        self._attr_sound_mode_list = list(self._sound_mode_map.values())
 
     # ---------- control ----------
     async def async_turn_on(self) -> None:
@@ -111,11 +134,13 @@ class SoundbarLocalEntity(CoordinatorEntity, MediaPlayerEntity):
             await self.coordinator.async_request_refresh()
 
     async def async_select_source(self, source: str) -> None:
-        await self._soundbar.select_input(source)
+        api_name = self._source_reverse.get(source, source)
+        await self._soundbar.select_input(api_name)
         await self.coordinator.async_request_refresh()
 
     async def async_select_sound_mode(self, sound_mode: str) -> None:
-        await self._soundbar.set_sound_mode(sound_mode)
+        api_name = self._sound_mode_reverse.get(sound_mode, sound_mode)
+        await self._soundbar.set_sound_mode(api_name)
         await self.coordinator.async_request_refresh()
 
     # ---------- properties ----------
@@ -134,13 +159,16 @@ class SoundbarLocalEntity(CoordinatorEntity, MediaPlayerEntity):
 
     @property
     def source(self):
-        return self.coordinator.data.get("input")
+        api_val = self.coordinator.data.get("input")
+        return self._source_map.get(api_val, api_val)
 
     @property
     def sound_mode(self):
-        return self.coordinator.data.get("sound_mode")
+        api_val = self.coordinator.data.get("sound_mode")
+        return self._sound_mode_map.get(api_val, api_val)
 
-    # ---------- coordinator update ----------
+    # ---------- coordinator / options update ----------
     @callback
     def _handle_coordinator_update(self) -> None:
+        self._refresh_mappings()
         self.async_write_ha_state()

--- a/custom_components/samsung_soundbar_local/number.py
+++ b/custom_components/samsung_soundbar_local/number.py
@@ -1,0 +1,90 @@
+"""Number entity for Samsung Soundbar Local – Subwoofer level."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from .const import DOMAIN
+from .soundbar import AsyncSoundbar
+
+_LOGGER = logging.getLogger(__name__)
+
+# Samsung soundbars typically expose a subwoofer range of -12 to +6.
+_SUB_MIN = -12
+_SUB_MAX = 6
+_SUB_DEFAULT = 0
+
+
+async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> None:
+    """Set up number entities from a config entry."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data["coordinator"]
+    soundbar: AsyncSoundbar = data["soundbar"]
+    host = entry.data["host"]
+
+    async_add_entities(
+        [SubwooferLevelNumber(coordinator, soundbar, host)],
+        True,
+    )
+
+
+class SubwooferLevelNumber(CoordinatorEntity, RestoreEntity, NumberEntity):
+    """Subwoofer level controlled via incremental +/- commands.
+
+    The Samsung API does not expose a direct get/set for the subwoofer level,
+    so we track the value locally and restore it across restarts.
+    Use the physical remote or SmartThings app to verify the initial level,
+    then adjust via this entity to keep it in sync.
+    """
+
+    _attr_native_min_value = _SUB_MIN
+    _attr_native_max_value = _SUB_MAX
+    _attr_native_step = 1
+    _attr_mode = NumberMode.SLIDER
+    _attr_icon = "mdi:speaker"
+
+    def __init__(self, coordinator, soundbar: AsyncSoundbar, host: str) -> None:
+        super().__init__(coordinator)
+        self._soundbar = soundbar
+        self._attr_unique_id = f"{host}_subwoofer_level"
+        self._attr_name = f"Soundbar {host} Subwoofer Level"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, host)},
+            manufacturer="Samsung",
+            model="Soundbar",
+            name=f"Soundbar {host}",
+        )
+        self._level: int = _SUB_DEFAULT
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last known subwoofer level on startup."""
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            try:
+                self._level = int(float(last_state.state))
+            except (ValueError, TypeError):
+                self._level = _SUB_DEFAULT
+
+    @property
+    def native_value(self) -> int:
+        return self._level
+
+    async def async_set_native_value(self, value: float) -> None:
+        target = int(value)
+        target = max(_SUB_MIN, min(_SUB_MAX, target))
+
+        while self._level != target:
+            if self._level < target:
+                await self._soundbar.sub_plus()
+                self._level += 1
+            else:
+                await self._soundbar.sub_minus()
+                self._level -= 1
+
+        self.async_write_ha_state()

--- a/custom_components/samsung_soundbar_local/strings.json
+++ b/custom_components/samsung_soundbar_local/strings.json
@@ -1,0 +1,53 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Samsung Soundbar Local",
+        "description": "Set up your Samsung soundbar for local control.",
+        "data": {
+          "host": "Host (IP address)",
+          "verify_ssl": "Verify SSL certificate"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Soundbar Options",
+        "description": "Choose what to configure.",
+        "menu_options": {
+          "sources": "Input sources",
+          "sound_modes": "Sound modes"
+        }
+      },
+      "sources": {
+        "title": "Input Sources",
+        "description": "Enter a display name for each input source. Leave blank to hide the source from the UI.",
+        "data": {
+          "HDMI_IN1": "HDMI 1",
+          "HDMI_IN2": "HDMI 2",
+          "E_ARC": "eARC",
+          "ARC": "ARC",
+          "D_IN": "Digital In",
+          "BT": "Bluetooth",
+          "WIFI_IDLE": "Wi-Fi"
+        }
+      },
+      "sound_modes": {
+        "title": "Sound Modes",
+        "description": "Enter a display name for each sound mode. Leave blank to hide the mode from the UI.",
+        "data": {
+          "STANDARD": "Standard",
+          "SURROUND": "Surround",
+          "GAME": "Game",
+          "MOVIE": "Movie",
+          "MUSIC": "Music",
+          "CLEARVOICE": "Clear Voice",
+          "DTS_VIRTUAL_X": "DTS Virtual X",
+          "ADAPTIVE": "Adaptive Sound"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION

- Add options flow so users can rename or hide input sources and sound modes via Settings → Devices & Services → Configure
- Add display-name mapping layer in media_player.py that translates between user-facing names and API identifiers
- Add number entity for subwoofer level (-12 to +6) with state restore
- Add strings.json for config/options flow UI labels
- Update README: fork attribution to @ZtF, installation instructions, display name configuration docs, subwoofer level docs, release instructions
- Bump version to 1.1.0, add @Potvis to codeowners
